### PR TITLE
Slick missing class in "p"

### DIFF
--- a/views/slick/partials/summary.jade
+++ b/views/slick/partials/summary.jade
@@ -1,9 +1,10 @@
 p.summary.darker
-			| Slick is a standalone selector engine that is totally slick.
+	| Slick is a standalone selector engine that is totally slick.
 
-		p.description.lighter Slick allows you to:
-
-		p Create your own custom pseudo-classes. Use the Parser by itself. Find nodes in XML documents.
+p.description.lighter 
+	| Slick allows you to:
+	br
+	| Create your own custom pseudo-classes. Use the Parser by itself. Find nodes in XML documents.
 
 .use
 


### PR DESCRIPTION
The "p" tag for 'Create your own custom pseudo-classes' had no class and
the CSS went messed up with that.
