### PR TITLE
use word "builder" instead of "download"

### DIFF
--- a/views/builder/partials/header-menu.jade
+++ b/views/builder/partials/header-menu.jade
@@ -1,6 +1,6 @@
 menu_project = {text: "Overview", url: "./"}
 menu_docs = {text: "Documentation", url: "docs"}
-menu_download = {text: "Download", url: "builder"}
+menu_download = {text: "Builder", url: "builder"}
 
 // 
 	menu_guides = {text: "Guides", url: "guides"}

--- a/views/core/partials/header-menu.jade
+++ b/views/core/partials/header-menu.jade
@@ -1,6 +1,6 @@
 menu_core = {text: "Overview", url: "/core"}
 menu_docs = {text: "Documentation", url: "/core/docs"}
-menu_download = {text: "Download", url: "/core/builder"}
+menu_download = {text: "Builder", url: "/core/builder"}
 
 mixin menu([menu_core, menu_docs, menu_download], page)
 

--- a/views/core/partials/summary.jade
+++ b/views/core/partials/summary.jade
@@ -29,7 +29,9 @@ p.description.lighter MooTools is about enhancing JavaScript.
 
 mixin older-version-select(versions)
 
-p.license Core is released under the Open Source MIT License
+p.license 
+	| To choose which modules to use visit the 
+	a(href='#{page}/builder') builder page.
 
 
 include big-icon

--- a/views/more/partials/header-menu.jade
+++ b/views/more/partials/header-menu.jade
@@ -1,6 +1,6 @@
 menu_more = {text: "Overview", url: "/more"}
 menu_docs = {text: "Documentation", url: "/more/docs"}
-menu_download = {text: "Download", url: "/more/builder"}
+menu_download = {text: "Builder", url: "/more/builder"}
 
 mixin menu([menu_more, menu_docs, menu_download], page)
 

--- a/views/more/partials/summary.jade
+++ b/views/more/partials/summary.jade
@@ -27,7 +27,9 @@ p.description.lighter MooTools More makes MooTools even More awesome.
 					| Repository
 					span.icon.github(aria-hidden='true')
 
-p.license More is released under the Open Source MIT License
+p.license 
+	| To choose which modules to use visit the 
+	a(href='#{page}/builder') builder page.
 
 include big-icon
 


### PR DESCRIPTION
As suggested by @gonchuki in the ML (which I also agree), the distintion between Download button and Builder page is not very clear.

By changing the link name it would be more clear.

Comments or "don't agree" welcome, so we merge or close this idea.
