### PR TITLE
small-fixes

### DIFF
--- a/builder/dependencies.js
+++ b/builder/dependencies.js
@@ -12,19 +12,23 @@ function makeString(type){
 	if (!type) return '';
 	return typeof type == 'string' ? type : type.join(', ');
 }
+function capitalise(name){
+	return name.charAt(0).toUpperCase() + name.slice(1);
+}
 
 
 module.exports = function(project, version){
 
+	var isCore = project == 'core';
 	var sourcePath = {
-		Core: projectPath('core', version),
-		More: projectPath('more', version)
+		Core: projectPath('core', version)
 	};
+	if (!isCore) sourcePath[capitalise(project)] = projectPath(project, version);
 
 	var packagerOptions = {
 		name: sourcePath,
 		noOutput: true,
-		removeCoreDependencies: project != 'core',
+		removeCoreDependencies: !isCore,
 		callback: function(src){
 			var headers = src.match(DESC_REGEXP);
 			headers.forEach(function(header){
@@ -38,7 +42,9 @@ module.exports = function(project, version){
 		}
 	};
 
-	var sourceFiles = [sourcePath.Core, sourcePath.More].reduce(function(files, folder){
+	var sourceFiles = Object.keys(sourcePath).map(function(proj){
+		return sourcePath[proj];
+	}).reduce(function(files, folder){
 		var folderPath = path.join(__dirname, '/../', folder);
 		return getFiles(folderPath, files, '.js');
 	}, []);	

--- a/views/css/header.styl
+++ b/views/css/header.styl
@@ -33,7 +33,7 @@
 				border-radius: 3px;
 				color: #000000;
 				font-size: 1em;
-				padding: 0.3em 1em 0.3em 1em;
+				padding: 0.3em 0.5em 0.3em 0.5em;
 				cursor: pointer;
 		
 	ul	
@@ -73,6 +73,7 @@ body.mootools #global-bar
 		font-size: 0.85em;
 		font-weight: 400;
 		padding: 0.4em 0.5em;
+		width: 12em;
 		&:focus
 			border-color: #acaaa7;
 

--- a/views/css/media.styl
+++ b/views/css/media.styl
@@ -251,6 +251,7 @@
 
 		section
 			position: relative;
+			clear: both;
 
 		div
 			margin-top: 1.5em;
@@ -407,7 +408,9 @@
 		div
 			float: left;
 			margin-left: 2em;
-			width: 8.6em;
+			width: 8.8em;
+		div:first-of-type
+			margin-left: 0.5em;
 
 		h3
 			margin-bottom: 0.3em;

--- a/views/layouts/main.jade
+++ b/views/layouts/main.jade
@@ -28,7 +28,8 @@ html
 
 		script(src='http://ajax.googleapis.com/ajax/libs/mootools/1.5.1/mootools-yui-compressed.js')
 		script(src='/js/main.js')
-		script
+		script.
+			// Google Analytics
 			(function(i, s, o, g, r, a, m){
 				i['GoogleAnalyticsObject'] = r;
 				i[r] = i[r] || function(){
@@ -40,6 +41,11 @@ html
 				a.src = g;
 				m.parentNode.insertBefore(a, m);
 			})(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+
+			//Kissmetrics
+			var KM_KEY = "bdc37c96b302d1ae5030c63f81ebb0fead91601e";
+			document.write(unescape("%3Cscript src='" + (("https:" == document.location.protocol) ? "https://s3.amazonaws.com/" : "http://") + "scripts.kissmetrics.com/t.js' type='text/javascript'%3E%3C/script%3E"));
+
 		block scripts
 
 	body(class=site)

--- a/views/partials/footer-navigation.jade
+++ b/views/partials/footer-navigation.jade
@@ -58,10 +58,8 @@ div
 		li
 			a(href='/more/docs') MooTools More
 
-script
+script.
 	// kissmetrics
-	var KM_KEY = "bdc37c96b302d1ae5030c63f81ebb0fead91601e";
-	document.write(unescape("%3Cscript src='" + (("https:" == document.location.protocol) ? "https://s3.amazonaws.com/" : "http://") + "scripts.kissmetrics.com/t.js' type='text/javascript'%3E%3C/script%3E"));
 	if ("/" == document.location.pathname.toLowerCase())
 		KM.record("Viewed Home");
 	if ("/more" == document.location.pathname.toLowerCase())


### PR DESCRIPTION
- fixed Jade [deprecation warning](http://stackoverflow.com/q/18343084/2256325)
- fixed KM error in console because it wasn’t loaded yet
- fixed Core builder that was showing More modules
- fix padding in header and footer to not overlap with logo near the mobile/desktop breakpoint width
- fixed position of examples being misplaced during resize
