### PR TITLE
use NPM's code since new version is out

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "slugify": "0.1",
     "stylus": "0.32",
     "sync-prompt": "^0.4.1",
-    "twitter": "https://github.com/SergioCrisostomo/node-twitter/tarball/master",
+    "twitter": "^0.2.13",
     "uglify-js": "^2.4.15",
     "unzip": "~0.1.9",
     "wrapup": "0.12",


### PR DESCRIPTION
Arian's suggestion to pass the response as second argument in the callback was merged at their repo so we can use from version `0.2.13`
