### PR TITLE
fix trailing slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ app.use(bodyParser.urlencoded({
 app.use(bodyParser.json());
 // fix trailing slashes in path
 app.use(function(req, res, next){
-    if (req.path.substr(-1) == '/' && req.path.length > 1){
+    if (req.path != '/' && req.path.substr(-1) == '/'){
         var query = req.url.slice(req.path.length);
         res.redirect(301, req.path.slice(0, -1) + query);
     } else {


### PR DESCRIPTION
Make all addresses ending with `/directory/`  resolve to `/directory`.

Fixes #119 (Disqus might complain with this, but I think we need to get it online to be sure)
