### PR TITLE
restore header in builder

### DIFF
--- a/views/builder/partials/header-menu.jade
+++ b/views/builder/partials/header-menu.jade
@@ -2,6 +2,8 @@ menu_project = {text: "Overview", url: "./"}
 menu_docs = {text: "Documentation", url: "docs"}
 menu_download = {text: "Builder", url: "builder"}
 
+mixin menu([menu_project, menu_docs, menu_download], page)
+
 // 
 	menu_guides = {text: "Guides", url: "guides"}
 	mixin menu([menu_project, menu_docs, menu_guides, menu_download], page)


### PR DESCRIPTION
I think this was hidden also when temp-removing the guides
