### PR TITLE
restore disqus comments

### DIFF
--- a/views/blog/index.jade
+++ b/views/blog/index.jade
@@ -12,7 +12,7 @@ block main
 				space = ""
 				| Written by #{post.author} on #{dateable(post.date, "D MMMM YYYY")}
 				mixin postedUnder(post.tags)
-				a(href="http://mootools.net/blog/#{post.permalink}#disqus_thread", data-disqus-identifier).comments
+				a(href="http://mootools.net/blog/#{post.permalink}/#disqus_thread", data-disqus-identifier).comments
 					| Comments
 
 			.post.short

--- a/views/partials/disqus_thread.jade
+++ b/views/partials/disqus_thread.jade
@@ -1,7 +1,7 @@
 #disqus_thread
 script.
 	var disqus_shortname = 'mootools-net';
-	var disqus_url = 'http://mootools.net/blog/#{post.permalink}';
+	var disqus_url = 'http://mootools.net/blog/#{post.permalink}/';
 
 	(function(){
 		var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;


### PR DESCRIPTION
Disqus needs apparently the old URL to work. So added `/` to the Disqus related link/variable
