### PR TITLE
Redirects for Docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,11 +124,15 @@ require('./developers')(app);
 // redirect old docs path
 var projects = require('./package.json')._projects;
 app.get('/docs/:project?/:module?/:file?', function(req, res){
-	if (!req.params.project || !projects[req.params.project]){
-		res.redirect(301, '/core/docs');
+	var project = projects[req.params.project] ? req.params.project : 'core';
+	var latestVersion = projects[project].versions[0];
+	if (!req.params.project) res.redirect(301, '/core/docs' + latestVersion);
+	var newPath;
+	if (!req.params.file){
+		newPath = ['/core/docs', latestVersion, req.params.project, req.params.module].join('/');
+	} else {
+		newPath = ['', req.params.project, 'docs', latestVersion, req.params.module, req.params.file].join('/');
 	}
-	var latestVersion = projects[req.params.project].versions[0];
-	var newPath = '/' + [req.params.project, 'docs', latestVersion, req.params.module, req.params.file].filter(Boolean).join('/');
 	res.redirect(301, newPath);
 });
 

--- a/lib/compile-md.js
+++ b/lib/compile-md.js
@@ -5,10 +5,23 @@ var hljs = require('highlight.js');
 var slug = require ('slugify');
 var jade = require('jade');
 var fs = require('fs');
+var projects = require('../package.json')._projects;
 
 var viewsDir = __dirname + '/../views';
 var headingTemplate = jade.compile(fs.readFileSync(viewsDir + '/partials/docs/heading.jade'));
 var blockcodeTemplate = jade.compile(fs.readFileSync(viewsDir + '/partials/docs/blockcode.jade'));
+var linkTemplate = jade.compile(fs.readFileSync(viewsDir + '/partials/docs/link.jade'));
+
+function preparePath(path){
+	if (path.indexOf('#') != -1){
+		var components = path.split('#');
+		var file = components[0].split('/').filter(Boolean).slice(-2).join('/');
+		path = file + '#' + components[1];
+	} else {
+		path = path.split('/').filter(Boolean).slice(-2).join('/');
+	}
+	return path;
+}
 
 function compile(md, path){
 
@@ -33,6 +46,27 @@ function compile(md, path){
 			code: code
 		});
 	};
+
+	// fix redirection of old paths
+	renderer.link = function(link, title, text){
+		var version = path.match(/[\d.]+/);
+		var project;
+
+		if (link.match(/^\//)){
+			project = link.match(/^\/([^\d\/]+)/)[1];
+			var mdPath = preparePath(link);
+			link = '/' + project + '/docs/' + version + '/' + mdPath;
+		}
+		if (link.match(/125$/)){
+			project = link.match(/([^\d\/]+)\d+$/)[1];
+			link = projects[project].versions.filter(function(version){
+				return version.slice(0, 3) == '1.2';
+			})[0];
+			text = text.replace(/\s([\d.]+)\s/, ' ' + link + ' ');
+		}
+
+		return linkTemplate({link: link, text: text});
+	}
 
 	var sidebar = [];
 	var links = {};

--- a/views/partials/docs/link.jade
+++ b/views/partials/docs/link.jade
@@ -1,0 +1,1 @@
+a(href=link, alt=text) !{text}


### PR DESCRIPTION
The idea is to redirect these type of links:
- `core/Module/File`
- `core/docs/Module/File`

The idea with this part under is to allow links from "popular pages" in the docs index to be linked to that popular page in the version they were clicked, thus `req.headers.referer`

```
var reqVersion = req.headers.referer && req.headers.referer.match(/(\d.\d.\d)/);
var version = reqVersion ? reqVersion[1] : versions[0];
```
