### PR TITLE
patch builder

### DIFF
--- a/views/builder/index.jade
+++ b/views/builder/index.jade
@@ -25,8 +25,8 @@ block main
 						| Download with compat layer
 
 					if project != 'Core'
-						label
-							input(type="checkbox", name="removeCoreDependencies", value="1")
+						label(style="display: none;")
+							input(type="checkbox", name="removeCoreDependencies", value="1", checked="true")
 							| Remove MooTools Core's dependencies
 								
 					label
@@ -71,8 +71,8 @@ block main
 					| Download with compat layer
 
 				if project != 'Core'
-					label
-						input(type="checkbox", name="removeCoreDependencies", value="1")
+					label(style="display: none;")
+						input(type="checkbox", name="removeCoreDependencies", value="1", checked="true")
 						| Remove MooTools Core's dependencies
 
 				label

--- a/views/more/partials/summary.jade
+++ b/views/more/partials/summary.jade
@@ -14,6 +14,7 @@ p.description.lighter MooTools More makes MooTools even More awesome.
 			form(method="post", action="../builder")
 				input(hidden, name="project", value="#{project}")
 				input(hidden, name="version", value="#{version}")
+				input(type="checkbox", name="removeCoreDependencies", value="1", checked="true", style="display: none;")
 				a.button.highlighted.getFile(href='#')
 					span
 						| Download


### PR DESCRIPTION
@anutron pointed yesterday that `Request.JSON` is not being packaged in one single file with Core + More, but is there when just Core is downloaded separately.

I have to learn this problem and make specs for it. In the meantime, since its kind of urgent matter we could patch builder page/jade so Core is not included by default (until we debug why Request.JSON is not being included).

If you agree to this I propose the website is updated asap.
