### PR TITLE
use old website's internal link names

### DIFF
--- a/lib/compile-md.js
+++ b/lib/compile-md.js
@@ -74,7 +74,7 @@ function compile(md, path){
 	var mdFile = path.split('/').pop();
 	renderer.header = function(text, level){
 
-		var innerLink = text.match(/{#(.*)}/);
+		var anchorName = text.match(/{#(.*)}/);
 		text = text.replace(/({#.*})/g, '');
 		if (index == -1) index++;
 
@@ -88,7 +88,7 @@ function compile(md, path){
 		var link;
 		if (level <= 2){
 			// handle duplicate headers
-			link = innerLink ? innerLink[1] : slug(text);
+			link = anchorName ? anchorName[1] : slug(text);
 			if (links[link]) link += '-' + links[link]++;
 			else links[link] = 1;
 


### PR DESCRIPTION
The links from the sidebar were working, but not some of the inner links.
Using the `{#innerLink}` inside the `.md` file will keep the old links alive and be consistent with the inner links in the docs also.

fixes #163
