### PR TITLE
fix numbers and bullets in list :before

### DIFF
--- a/views/css/docs.styl
+++ b/views/css/docs.styl
@@ -152,7 +152,7 @@
 			list-style: none; /* Remove default numbering */
 			*list-style: decimal; /* Keep using default numbering for IE6/7 */
 			position: relative;
-			li
+			> li
 				margin-top: 0.5em
 				padding-left 1.5em
 				&:before
@@ -179,6 +179,7 @@
 				left: -1em;
 				font-size: 100%;
 				margin: 0.2em 0.5em 0 0;
+				top: 0em;
 
 		pre
 			margin: 0.5em 0 0;


### PR DESCRIPTION
Besides the problem described in #196 there was a numbering problem like:

![screen shot 2014-11-20 at 23 00 25](https://cloud.githubusercontent.com/assets/5614559/5133935/916aa29c-7109-11e4-967c-de4c7573f680.png)

This pull request fixes that and will change the looks to:

![screen shot 2014-11-20 at 22 56 16](https://cloud.githubusercontent.com/assets/5614559/5133951/a5f07264-7109-11e4-9d4b-f1a1340fe3e3.png)

fixes #196 
