### PR TITLE
Refactor module order in builder, allow version auto-update

### DIFF
--- a/builder/dependencies.js
+++ b/builder/dependencies.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 var fs = require('fs');
 var path = require('path');
@@ -69,7 +69,7 @@ module.exports = function(project, version, callback){
 				return obj.name == module || obj.file == module;
 			})[0];
 		});
-		if (orderedModules.length != headers.length) console.log('Err: package.yml and files missmatch');
+		if (orderedModules.length != headers.length) console.log('Err: package.yml and Source files missmatch');
 		callback(err, !err && orderedModules);
 	});	
 };

--- a/builder/dependencies.js
+++ b/builder/dependencies.js
@@ -1,55 +1,76 @@
-"use strict";
+'use strict';
 
-var YAML = require('js-yaml');
+var fs = require('fs');
 var path = require('path');
-var fs = require("fs");
-var getFiles = require('../lib/getFiles');
-var projectPath = require('../lib/projectPath');
-var packager = require('mootools-packager');
+var async = require('async');
+var YAML = require('js-yaml');
+var pkg = require('../package.json');
 var DESC_REGEXP = /\/\*\s*^---([\s\S]+?)^(?:\.\.\.|---)\s*\*\//mg;
 
 function makeString(type){
 	if (!type) return '';
 	return typeof type == 'string' ? type : type.join(', ');
 }
-function capitalise(name){
-	return name.charAt(0).toUpperCase() + name.slice(1);
+
+function getPackageYML(project, version, callback){
+	var file = path.join(__dirname, '..', pkg._buildOutput, project, 'docs', project + '-' + version, 'package.yml');
+	fs.readFile(file, 'utf-8', function(err, data){
+		var modules = YAML.load(data).sources.map(function(module){
+			return path.basename(module, '.js');
+		});
+		callback(err, modules);
+	});
 }
 
-
-module.exports = function(project, version){
-
-	var isCore = project == 'core';
-	var sourcePath = {
-		Core: projectPath('core', version)
-	};
-	if (!isCore) sourcePath[capitalise(project)] = projectPath(project, version);
-
-	var packagerOptions = {
-		name: sourcePath,
-		noOutput: true,
-		removeCoreDependencies: !isCore,
-		callback: function(src){
-			var headers = src.match(DESC_REGEXP);
-			headers.forEach(function(header){
-				var yamlHeader = YAML.load(header.slice(2, -2));
-				filesInfo[yamlHeader.name] = {
-					req: makeString(yamlHeader.requires), 
-					prov: makeString(yamlHeader.provides), 
-					desc: yamlHeader.description
-				};
+function getHeaders(project, version, callback){
+	var SourceFolder = path.join(__dirname, '..', pkg._buildOutput, project, 'docs', project + '-' + version, 'Source');
+	fs.readdir(SourceFolder, function(err, subFolders){
+		subFolders = subFolders.filter(function(file){
+			var filePath = path.join(SourceFolder, file);
+			return fs.statSync(filePath).isDirectory();
+		});
+		async.map(subFolders, function(folder, cbFolder){
+			var subFolder = path.join(SourceFolder, folder);
+			fs.readdir(subFolder, function(err, files){
+				async.map(files, function(file, cbFile){
+					var filePath = path.join(subFolder, file);
+					fs.readFile(filePath, 'utf-8', function(err, src){
+						var header = src.match(DESC_REGEXP)[0];
+						var yaml = YAML.load(header.slice(2, -2));
+						cbFile(err, !err && {
+							name: yaml.name,
+							file: path.basename(file, '.js'),
+							req: makeString(yaml.requires), 
+							prov: makeString(yaml.provides), 
+							desc: yaml.description
+						});
+					});
+				}, function(err, files){
+					cbFolder(err, files);
+				});
 			});
-		}
-	};
+		}, function(err, headers){
+			callback(err, headers);
+		});	
+	});
+}
 
-	var sourceFiles = Object.keys(sourcePath).map(function(proj){
-		return sourcePath[proj];
-	}).reduce(function(files, folder){
-		var folderPath = path.join(__dirname, '/../', folder);
-		return getFiles(folderPath, files, '.js');
-	}, []);	
-
-	var filesInfo = {};
-	packager(sourceFiles, packagerOptions);
-	return filesInfo;
+module.exports = function(project, version, callback){
+	async.parallel([
+		async.apply(getPackageYML, project, version),
+		async.apply(getHeaders, project, version)
+	], function(err, res){
+		
+		var headers = res[1].reduce(function(a, b){
+			return a.concat(b);
+		});
+		var orderedModules = res[0].map(function(module, i){
+			return headers.filter(function(obj){
+				return obj.name == module || obj.file == module;
+			})[0];
+		});
+		if (orderedModules.length != headers.length) console.log('Err: package.yml and files missmatch');
+		callback(err, !err && orderedModules);
+	});	
 };
+

--- a/middleware/packageJSONreader.js
+++ b/middleware/packageJSONreader.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function(project){
+
+	return function(){
+		var pkgPath = path.join(__dirname, '..', 'package.json');
+		if (require.cache[pkgPath]) delete require.cache[pkgPath];
+		var pkg = require(pkgPath);
+
+		return {
+			buildOutput: pkg._buildOutput,
+			versions: pkg._projects[project].versions,
+			lastVersion: pkg._projects[project].versions[0]
+		}
+	}
+};

--- a/views/builder/index.jade
+++ b/views/builder/index.jade
@@ -51,13 +51,13 @@ block main
 					td Provides
 					td Description
 
-				each yaml, module in dependencies
-					- var file = project + "/" + module;
+				each yaml in dependencies
+					- var file = project + "/" + yaml.name;
 					- var hashRequested = hashDependencies.indexOf(file) != -1;
 					tr
 						td
 							input(type="checkbox", value=file, name="modules[]", data-provides="#{yaml.prov}", data-requires="#{yaml.req}", checked=hashRequested, class=hashRequested ? "activeChoice" : "")
-						td #{module}
+						td #{yaml.name}
 						td #{yaml.prov}
 						td #{yaml.desc}
 


### PR DESCRIPTION
Refactor module order in builder:
 - refactored `dependencies.js` so it uses `package.yml` order of modules.
 - the YAML header content is still fetched from each files, now more async.
 - added a doublecheck that yml packages-list is same amount as files found by walking the directories

Allow version auto-update:
 - added `fs.watch` to both Core and More, which means that when cache folder is changed it will now refresh the last version by reading again the `package.json` info

fixes #186, fixes #157