### PR TITLE
restore p element to assure correct margin under buttons

### DIFF
--- a/views/more/partials/summary.jade
+++ b/views/more/partials/summary.jade
@@ -23,6 +23,7 @@ p.description.lighter MooTools More makes MooTools even More awesome.
 					br
 					| Repository
 					span.icon.github(aria-hidden='true')
+p.license 
 
 include big-icon
 


### PR DESCRIPTION
A previous fix removed a `margin` that should be there.
Restored de `<p>` element to assure the margin is not lost.

Problem looked like this:

![screen shot 2015-01-01 at 17 09 20](https://cloud.githubusercontent.com/assets/5614559/5592633/d4528d4a-91d9-11e4-9c21-43707937f059.png)
