### PR TITLE
use Core's contribute info

### DIFF
--- a/views/partials/header.jade
+++ b/views/partials/header.jade
@@ -38,7 +38,7 @@
 
 				mixin menu-item('/blog', 'Blog', site == 'blog')
 				mixin menu-item('/forge', 'Forge', site == 'forge')
-				mixin menu-item("http://github.com/mootools", 'Contribute')
+				mixin menu-item("http://github.com/mootools/mootools-core#contribute", 'Contribute')
 
 			form#search(role='search', method='get', action='/search')
 				label(for='search-field')


### PR DESCRIPTION
Use [github.com/mootools/mootools-core#contribute](http://github.com/mootools/mootools-core#contribute) link so people that click "Contribute" in the website see the instructions directly instead of different repos.
