### PR TITLE
Add "service.js" using forever-monitor + basic logging functionality.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 *.tern-port
 config/api_keys.json
 config/databases.json
+config/log.json

--- a/config/init.d/mootools-website
+++ b/config/init.d/mootools-website
@@ -26,7 +26,7 @@ DAEMON=/usr/local/bin/node
 DAEMON_DIR=/opt/mootools/$SHORTNAME
 DAEMON_USER=www-data
 
-APP=index
+APP=service
 APP_ARGS="-p $SOCKET"
 APP_ENV=production
 
@@ -53,6 +53,7 @@ do_start() {
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $DAEMON_USER --exec $DAEMON --test > /dev/null || return 1
+	rm -f "$SOCKET"
 	NODE_ENV="$APP_ENV" start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --chuid $DAEMON_USER --chdir $DAEMON_DIR --exec $DAEMON -- $APP $APP_ARGS > /dev/null || return 2
 }
 
@@ -68,8 +69,21 @@ do_stop() {
 	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --exec $DAEMON
 	RETVAL="$?"
 	[ "$RETVAL" = 2 ] && return 2
-	rm -f $PIDFILE $SOCKET
+	rm -f "$PIDFILE" "$SOCKET"
 	return "$RETVAL"
+}
+
+#
+# Function that sends a SIGHUP to the daemon/service
+#
+do_reload() {
+	# Return
+	#   0 if the signal was sent (and old socket was removed)
+	#   1 if the signal could not be sent
+	start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null || return 1
+	rm -f "$SOCKET"
+	start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE --exec $DAEMON
+	return 0
 }
 
 case "$1" in
@@ -92,7 +106,12 @@ case "$1" in
 	status)
 		status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
 		;;
-	restart|force-reload)
+	reload|force-reload)
+		log_daemon_msg "Reloading $DESC" "$NAME"
+		do_reload
+		log_end_msg $?
+		;;
+	restart)
 		log_daemon_msg "Restarting $DESC" "$NAME"
 		do_stop
 		case "$?" in
@@ -111,7 +130,7 @@ case "$1" in
 		esac
 		;;
 	*)
-		echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+		echo "Usage: $SCRIPTNAME {start|stop|status|restart|reload|force-reload}" >&2
 		exit 3
 		;;
 esac

--- a/config/init.d/mootools-website
+++ b/config/init.d/mootools-website
@@ -74,6 +74,18 @@ do_stop() {
 }
 
 #
+# Function that sends a SIGUSR2 to the daemon/service
+#
+do_reload_logs() {
+	# Return
+	#   0 if the signal was sent
+	#   1 if the signal could not be sent
+	start-stop-daemon --stop --signal USR2 --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null || return 1
+	start-stop-daemon --stop --signal USR2 --quiet --pidfile $PIDFILE --exec $DAEMON
+	return 0
+}
+
+#
 # Function that sends a SIGHUP to the daemon/service
 #
 do_reload() {
@@ -106,6 +118,11 @@ case "$1" in
 	status)
 		status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
 		;;
+	reload-logs)
+		log_daemon_msg "Reloading logs of $DESC" "$NAME"
+		do_reload_logs
+		log_end_msg $?
+		;;
 	reload|force-reload)
 		log_daemon_msg "Reloading $DESC" "$NAME"
 		do_reload
@@ -130,7 +147,7 @@ case "$1" in
 		esac
 		;;
 	*)
-		echo "Usage: $SCRIPTNAME {start|stop|status|restart|reload|force-reload}" >&2
+		echo "Usage: $SCRIPTNAME {start|stop|status|restart|reload|reload-logs|force-reload}" >&2
 		exit 3
 		;;
 esac

--- a/config/log.sample.json
+++ b/config/log.sample.json
@@ -1,0 +1,4 @@
+{
+	"outFile": "tests/out.log",
+	"errFile": "tests/err.log"
+}

--- a/config/logrotate.d/mootools-website
+++ b/config/logrotate.d/mootools-website
@@ -1,0 +1,13 @@
+/var/opt/mootools/log/mootools-website.*.log {
+	weekly
+	missingok
+	rotate 52
+	compress
+	delaycompress
+	notifempty
+	create 0640 www-data adm
+	sharedscripts
+	postrotate
+		service mootools-website reload-logs
+	endscript
+}

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,96 @@
+"use strict";
+
+var fs = require('fs');
+
+var silent = false,
+	monitors = [],
+	files = {},
+	streams = {};
+
+function close(type){
+	if (streams[type]){
+		streams[type].end();
+		streams[type] = null;
+	}
+}
+
+function open(type, file){
+	if (file){
+		files[type] = file;
+	} else {
+		file = files[type];
+	}
+
+	close(type);
+
+	if (file){
+		var stream = fs.createWriteStream(file, {
+			flags: 'a+',
+			defaultEncoding: 'utf8',
+			mode: parseInt('640', 8)
+		});
+		stream.addListener('error', function(error){
+			stream.end();
+			streams[type] = null;
+			if (monitors.length){
+				for (var i = 0, l = monitors.length; i < l; ++i){
+					monitors[i].emit('error', error);
+				}
+			} else {
+				throw error;
+			}
+		});
+		streams[type] = stream;
+	}
+}
+
+function write(type, data){
+	var stream = streams[type];
+	if (stream){
+		stream.write('[' + (new Date()).toISOString() +  '] ' + data);
+	}
+}
+
+function configure(configuration){
+	if (configuration.silent != null) silent = configuration.silent;
+	if (configuration.outFile) open('out', configuration.outFile);
+	if (configuration.errFile) open('err', configuration.errFile);
+}
+
+function reload(){
+	var types = Object.keys(files);
+	for (var i = 0, l = types.length; i < l; ++i){
+		open(types[i]);
+	}
+}
+
+function attach(monitor){
+	if (monitors.indexOf(monitor) == -1) monitors.push(monitor);
+	monitor.addListener('stdout', log);
+	monitor.addListener('stderr', logError);
+}
+
+function detach(monitor){
+	var index = monitors.indexOf(monitor);
+	if (index > -1) monitors.splice(index, 1);
+	monitor.removeListener('stdout', log);
+	monitor.removeListener('stderr', logError);
+}
+
+function log(data){
+	write('out', data);
+	if (!silent) process.stdout.write(data);
+}
+
+function logError(data){
+	write('err', data);
+	if (!silent) process.stderr.write(data);
+}
+
+exports.configure = configure;
+exports.reload = reload;
+exports.attach = attach;
+exports.detach = detach;
+
+exports.write = function(data){ return log(data + '\n'); };
+exports.error = function(data){ return logError(data + '\n'); };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "errorhandler": "~1.2.0",
     "event-stream": "~3.0.16",
     "express": "4.9",
-    "forever": "0.10",
+    "forever-monitor": "~1.6",
     "front-matter": "~0.1.3",
     "fs-extra": "^0.22.1",
     "github": "0.1",

--- a/service.js
+++ b/service.js
@@ -1,0 +1,54 @@
+"use strict";
+
+var app = 'index',
+	name = 'mootools-website';
+
+var Monitor = require('forever-monitor').Monitor;
+
+var monitor = new Monitor(__dirname + '/' + app + '.js', {
+	minUptime: 2000,
+	args: process.argv.splice(2)
+});
+
+function stop(){
+	console.error('** Requested stop of ' + name);
+	monitor.stop();
+}
+
+function reload(){
+	console.error('** Requested reload of ' + name);
+	monitor.restart();
+}
+
+process.addListener('SIGINT', stop);
+process.addListener('SIGTERM', stop);
+process.addListener('SIGHUP', reload);
+
+monitor.addListener('start', function(){
+	console.error('** Starting ' + name + ' monitor');
+});
+
+monitor.addListener('stop', function(){
+	console.error('** Stopping ' + name + ' monitor');
+});
+
+monitor.addListener('exit:code', function(code){
+	if (code == null) code = 0;
+	console.error('** Detected ' + name + ' process exited (exit code ' + code + ')');
+});
+
+monitor.addListener('restart', function(){
+	console.error('** Restarting ' + name + ' process (#' + monitor.times + ')');
+});
+
+monitor.addListener('error', function(error){
+	if (error.stack){
+		console.error('** ' + error.stack);
+	} else if (error.message) {
+		console.error('** Error: ' + error.message);
+	} else {
+		console.error('** Error: ' + error);
+	}
+});
+
+monitor.start();


### PR DESCRIPTION
Most important changes:
- **package.json**:
  * removed dependency on `forever`,
  * added dependency on `forever-monitor`.
- **config/init.d/mootools-website**:
  * now runs `service.js` instead of `index.js`.
- **service.js**:
  * uses `forever-monitor` to run and interact with a process running `index.js`.
- **lib/log.js**:
  * logging functionality for `service.js`, both to stdout/stderr and to files.

Why `forever-monitor` and not `forever`?
The reason we want either of these is to have a "master" kind of process that interacts with and keeps an eye on the application process. What we don't need is another arbitrary process manager (the "actual" process manager, sysvinit/upstart/systemd, can do that fine).
`forever-monitor` is only the "master process" part of `forever`, it turned out to be easy to integrate and when integrated it's easy to hook into (e.g. for restarting, stopping and/or logging kinds of things). `forever` would not really be integrated in the application (it's normally even installed and configured globally), and it would add a layer of process management we're not looking for.
