### PR TITLE
add download attribute to anchor

### DIFF
--- a/views/builder/index.jade
+++ b/views/builder/index.jade
@@ -32,7 +32,7 @@ block main
 								option(value="keepDependencies") Add Core (only dependencies)
 
 					label
-						a.button.highlighted.getFile(href='#')
+						a.button.highlighted.getFile(href='#', download)
 							span Download MooTools #{project}
 							span.version Ver. #{version}
 							span.icon.download(aria-hidden='true')
@@ -80,7 +80,7 @@ block main
 							option(value="keepDependencies") Add Core (only dependencies)
 
 				label
-					a.button.highlighted.getFile(href='#')
+					a.button.highlighted.getFile(href='#', download)
 						span Download custom MooTools #{project}
 						span.version Ver. #{version}
 						span.icon.download(aria-hidden='true')

--- a/views/core/partials/summary.jade
+++ b/views/core/partials/summary.jade
@@ -14,7 +14,7 @@ p.description.lighter MooTools is about enhancing JavaScript.
 			form(method="post", action="../builder")
 				input(hidden, name="project", value="#{project}")
 				input(hidden, name="version", value="#{version}")
-				a.button.highlighted.getFile(href='#')
+				a.button.highlighted.getFile(href='#', download)
 					span
 						| Download
 						span.version Ver. #{version}


### PR DESCRIPTION
because windows defender thinks .js files that are dangerous and auto-deletes them when download is complete.