### PR TITLE
Patches

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ require('./middleware/build-static')(app, {
 	dirname: __dirname
 });
 
-app.use(express.static(__dirname + '/public'));
+app.use(express.static(__dirname + '/public', {redirect : false}));
 
 // github, twitter & blog feeds
 var githubEvents = require('./middleware/githubEvents')({

--- a/views/layouts/main.jade
+++ b/views/layouts/main.jade
@@ -42,10 +42,6 @@ html
 				m.parentNode.insertBefore(a, m);
 			})(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
 
-			//Kissmetrics
-			var KM_KEY = "bdc37c96b302d1ae5030c63f81ebb0fead91601e";
-			document.write(unescape("%3Cscript src='" + (("https:" == document.location.protocol) ? "https://s3.amazonaws.com/" : "http://") + "scripts.kissmetrics.com/t.js' type='text/javascript'%3E%3C/script%3E"));
-
 		block scripts
 
 	body(class=site)

--- a/views/partials/disqus_count.jade
+++ b/views/partials/disqus_count.jade
@@ -1,4 +1,4 @@
-script
+script.
 	var disqus_shortname = 'mootools-net';
 	(function (){
 		var s = document.createElement('script'); s.async = true;


### PR DESCRIPTION
- was having intermitent problems with a redirect loop related to trailing slashes. Applied [this patch](http://stackoverflow.com/a/15458555/2256325). 
- Kissmetrics: was giving a browser warning. Removed it.
>A Parser-blocking, cross-origin script, http://scripts.kissmetrics.com/t.js, is invoked via document.write. This may be blocked by the browser if the device has poor network connectivity. See https://www.chromestatus.com/feature/5718547946799104 for more details.
 - Fixed Jade deprecated sintax.