### PR TITLE
Add SSL configuration

### DIFF
--- a/blog/posts/mootools-depender-a-build-tool-for-mootools-javascript-libraries.md
+++ b/blog/posts/mootools-depender-a-build-tool-for-mootools-javascript-libraries.md
@@ -37,8 +37,8 @@ The server side applications are [available on github](http://github.com/anutron
 
 Libraries that you download with Depender will all have a standard header that looks something like this:
 
-        //MooTools, <http://mootools.net>, My Object Oriented (JavaScript) Tools. Copyright (c) 2006-2009 Valerio Proietti, <https://github.com/kamicane>, MIT Style License.
-        //MooTools More, </more>. Copyright (c) 2006-2009 Aaron Newton <http://clientcide.com/>, Valerio Proietti <https://github.com/kamicane> & the MooTools team </developers>, MIT Style License.
+        //MooTools, <https://mootools.net>, My Object Oriented (JavaScript) Tools. Copyright (c) 2006-2009 Valerio Proietti, <https://github.com/kamicane>, MIT Style License.
+        //MooTools More, <https://mootools.net/more>. Copyright (c) 2006-2009 Aaron Newton <http://clientcide.com/>, Valerio Proietti <https://github.com/kamicane> & the MooTools team <https://mootools.net/developers>, MIT Style License.
         //Contents: Core, Browser, Array, Function, Number, String, Hash, Event, Class, Class.Extras, Element, Element.Event, Element.Style, Element.Dimensions, Selectors, DomReady, JSON, Cookie, Swiff, Fx, Fx.CSS, Fx.Tween, Fx.Morph, Fx.Transitions, Request, Request.HTML, Request.JSON, More, Element.Shortcuts, Element.Measure, Fx.Reveal
         //This lib: http://clientcide.com/js/build.php?requireLibs=mootools-core&require=Fx.Reveal&compression=none
 

--- a/blog/posts/selectors-on-fire-a-tale-of-pseudoselectors.md
+++ b/blog/posts/selectors-on-fire-a-tale-of-pseudoselectors.md
@@ -142,7 +142,7 @@ The html template for all frameworks is the same Andrew Dupont used in his DOM S
 His test was flawed though, as every framework was just included in the same page. This created prototypes conflict, so speed results were unreliable.
 
 In the demo I tried to include the latest development version of the frameworks where possible.
-Currently in the demo: [mootools](http://mootools.net), [prototype](http://prototypejs.org), [jquery](http://jquery.com), [ext](http://extjs.com/), [cssQuery](http://dean.edwards.name/my/cssQuery/) and [dojo](http://dojotoolkit.org/).
+Currently in the demo: [mootools](https://mootools.net), [prototype](http://prototypejs.org), [jquery](http://jquery.com), [ext](http://extjs.com/), [cssQuery](http://dean.edwards.name/my/cssQuery/) and [dojo](http://dojotoolkit.org/).
 
 So welcome to the battle of the frameworks, and may the best win. Meet [SlickSpeed](/slickspeed).
 

--- a/builder/index.js
+++ b/builder/index.js
@@ -10,7 +10,7 @@ var projectPath = require('../lib/projectPath');
 var bodyParser = require('body-parser');
 var pkgProjects = require('../package.json')._projects;
 var builderHash = require('../lib/BuilderHash')(require('../config/databases.json'));
-var copyright = '/* MooTools: the javascript framework. license: MIT-style license. copyright: Copyright (c) 2006-' + new Date().getFullYear() + ' [Valerio Proietti](http://mootools.net/).*/ ';
+var copyright = '/* MooTools: the javascript framework. license: MIT-style license. copyright: Copyright (c) 2006-' + new Date().getFullYear() + ' [Valerio Proietti](https://mootools.net/).*/ ';
 
 function uglify(source){
 	var uglified = UglifyJS.minify(source, {
@@ -81,7 +81,7 @@ function processPost(req, res, next){
 		if (minified) data = uglify(data);
 
 		data = copyright + '\n' +
-			(results[1] ? '/*!\nWeb Build: http://mootools.net/' + project_ + '/builder/' + results[1].hash + '\n*/\n' : '') +
+			(results[1] ? '/*!\nWeb Build: https://mootools.net/' + project_ + '/builder/' + results[1].hash + '\n*/\n' : '') +
 			data;
 
 		res.setHeader('Content-Type', 'application/javascript');

--- a/config/nginx/mootools.net
+++ b/config/nginx/mootools.net
@@ -20,6 +20,17 @@ server {
 		try_files $uri.html =404;
 	}
 
+	location ~ '^/\.well-known/acme-challenge/[A-Za-z0-9_-]{43}$' {
+		proxy_pass http://127.0.0.1:50080;
+
+		proxy_redirect off;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_connect_timeout 10s;
+		proxy_pass_header Server;
+	}
+
 	location ~ ^/([^/]*)(?:/(.*))?$ {
 		try_files $uri $uri/index.html @microsites;
 	}

--- a/config/nginx/mootools.net
+++ b/config/nginx/mootools.net
@@ -1,7 +1,10 @@
 server {
 
-	listen 80; ## listen for ipv4
-	listen [::]:80; ## listen for ipv6
+	listen 443 ssl; ## listen for ipv4
+	listen [::]:443 ssl; ## listen for ipv6
+
+	ssl_certificate     /srv/letsencrypt/live/mootools.net/fullchain.pem;
+	ssl_certificate_key /srv/letsencrypt/live/mootools.net/privkey.pem;
 
 	server_name mootools.net;
 
@@ -18,17 +21,6 @@ server {
 
 	location ~ \.php$ {
 		try_files $uri.html =404;
-	}
-
-	location ~ '^/\.well-known/acme-challenge/[A-Za-z0-9_-]{43}$' {
-		proxy_pass http://127.0.0.1:50080;
-
-		proxy_redirect off;
-		proxy_set_header Host $host;
-		proxy_set_header X-Real-IP $remote_addr;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_connect_timeout 10s;
-		proxy_pass_header Server;
 	}
 
 	location ~ ^/([^/]*)(?:/(.*))?$ {
@@ -119,10 +111,37 @@ server {
 
 server {
 
-	listen 80; ## listen for ipv4
-	listen [::]:80; ## listen for ipv6
+	listen 443 ssl; ## listen for ipv4
+	listen [::]:443 ssl; ## listen for ipv6
+
+	ssl_certificate     /srv/letsencrypt/live/mootools.net/fullchain.pem;
+	ssl_certificate_key /srv/letsencrypt/live/mootools.net/privkey.pem;
 
 	server_name www.mootools.net;
 	return 301 $scheme://mootools.net$request_uri;
+
+}
+
+server {
+
+	listen 80; ## listen for ipv4
+	listen [::]:80; ## listen for ipv6
+
+	server_name mootools.net www.mootools.net;
+
+	location ~ '^/\.well-known/acme-challenge/[A-Za-z0-9_-]{43}$' {
+		proxy_pass http://127.0.0.1:50080;
+
+		proxy_redirect off;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_connect_timeout 10s;
+		proxy_pass_header Server;
+	}
+
+	location / {
+		return 301 https://mootools.net$request_uri;
+	}
 
 }

--- a/views/layouts/main.jade
+++ b/views/layouts/main.jade
@@ -16,8 +16,8 @@ html
 		title= title
 
 		if webfonts
-			link(rel="stylesheet", href="http://fonts.googleapis.com/css?family=Roboto:200,300,400,600,700,200italic,300italic,400italic,600italic,700italic")
-			link(rel="stylesheet", href="http://fonts.googleapis.com/css?family=Source+Code+Pro:200,300,400,500,600,700")
+			link(rel="stylesheet", href="https://fonts.googleapis.com/css?family=Roboto:200,300,400,600,700,200italic,300italic,400italic,600italic,700italic")
+			link(rel="stylesheet", href="https://fonts.googleapis.com/css?family=Source+Code+Pro:200,300,400,500,600,700")
 
 		link(rel='stylesheet', href='/css/style.css')
 


### PR DESCRIPTION
Changes to add SSL "support" in three steps:

1. Add temporary configuration to allow ACME verification, to get an SSL certificate from https://letsencrypt.org/.
2. Change nginx configuration to enable SSL.
3. Replace some references of http://mootools.net.

**Edit:** Added another commit:

4. Fix URLs of google fonts stylesheets.