### PR TITLE
Remove of IRC links after freenode drama.

### DIFF
--- a/views/partials/footer-navigation.jade
+++ b/views/partials/footer-navigation.jade
@@ -17,8 +17,6 @@ div
 		span.slider(aria-hidden='true')
 	ul
 		li
-			a(href='irc://irc.freenode.net/#mootools', target='_blank') IRC Channel
-		li
 			a(href='http://groups.google.com/group/mootools-users', target='_blank') User Group
 		li
 			a(href='http://mootorial.com', target='_blank') The MooTorial


### PR DESCRIPTION
I've been observing the freenode drama for a few days and up until now there was no evidence of abuse of power, but since now there is at least one case of OP abusing their power I think it's best to remove the link to the freenode channel at least for now.

We could replace the link and use another server, but since MooTools is pushing up the daisies and since I'm not sure of how many of us still actively monitor the channel I think the best option here is just to remove the link from the footer. users that have to maintain an older website can still reach out in the mailing list.

Source:
- https://www.devever.net/~hl/freenode_abuse